### PR TITLE
Updated config parameter names for clarity.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ module.exports = function(grunt) {
     grunt.config.set('pkg', pkg);
 
     var config = grunt.file.readJSON('config.json');
-    grunt.config.set('device.host', config.device);
+    grunt.config.set('device.host', config.deviceAddress);
 
     // build webapp version date & hash into complied js
     grunt.file.write(
@@ -328,9 +328,9 @@ module.exports = function(grunt) {
   grunt.registerTask('deploy', function(){
     var config = grunt.file.readJSON('config.json');
 
-    grunt.config.set('device.host', config.device);
-    grunt.config.set('local.ip', config.localIP);
-    grunt.config.set('local.port', config.port);
+    grunt.config.set('device.host', config.deviceAddress);
+    grunt.config.set('local.ip', config.localDevelopmentIP);
+    grunt.config.set('local.port', config.localDevelopmentPort);
 
     grunt.task.run(['build', 'http:index', 'http:js', 'http:css', 'http:unauth']);
   });

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ grunt deploy
 
 Put webapp files onto the device specified in `config.json` by `deviceAddress`. This requires the default `grunt` task to already be running in another terminal and accessible at the address specified by `localDevelopmentIP` in the config file.
 
-_Note: `grunt deploy` will silently fail if the `localDevelopmentIP` address is not configured correctly_
+_Note: `grunt deploy` will silently fail if the `localDevelopmentIP` address is not configured correctly in `config.json`._
 
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Will start a task that listens for file changes, and compile/compress HTML, CSS 
 #### Config.json
 
 Edit `config.json` to specify:
-  - `localDevelopmentIP`: address (e.g. `12.34.56.789`) of running the local development server. *Note: `grunt deploy` will silently fail if this address is not configured correctly*
+  - `localDevelopmentIP`: address (e.g. `12.34.56.89`) of running the local development server. *Note: `grunt deploy` will silently fail if this address is not configured correctly*
   - `localDevelopmentPort`: port for local development server (the default grunt server runs on 5002).
-  - `deviceAddress`: address (e.g. `12.34.56.789` or `device.local`) of the device to communicate with.
+  - `deviceAddress`: address (e.g. `12.34.56.78` or `device.local`) of the device to communicate with.
 
 The WiConnect WebApp has been primarily developed using [Jade templating](http://jade-lang.com/) and [LESS CSS pre-processing language](http://lesscss.org/)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ Will start a task that listens for file changes, and compile/compress HTML, CSS 
 
 #### Config.json
 
-Edit `config.json` to specify the `localIP` address and `port` for running a development server, remote device IP address for the device to communicate with.
+Edit `config.json` to specify:
+  - `localDevelopmentIP`: address (e.g. `12.34.56.789`) of running the local development server. *Note: `grunt deploy` will silently fail if this address is not configured correctly*
+  - `localDevelopmentPort`: port for local development server (the default grunt server runs on 5002).
+  - `deviceAddress`: address (e.g. `12.34.56.789` or `device.local`) of the device to communicate with.
 
 The WiConnect WebApp has been primarily developed using [Jade templating](http://jade-lang.com/) and [LESS CSS pre-processing language](http://lesscss.org/)
 
@@ -90,7 +93,7 @@ If the file `public/css/wiconnect.css` exists, it will be used in the build proc
 grunt deploy
 ````
 
-Put webapp files onto the device specified in `config.json`. This requires a server, the default `grunt` task to alread be running in another terminal.
+Put webapp files onto the device specified in `config.json` by `deviceAddress`. This requires the default `grunt` task to already be running in another terminal and accessible at the address specified by `localDevelopmentIP` in the config file.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Will start a task that listens for file changes, and compile/compress HTML, CSS 
 #### Config.json
 
 Edit `config.json` to specify:
-  - `localDevelopmentIP`: address (e.g. `12.34.56.89`) of running the local development server. *Note: `grunt deploy` will silently fail if this address is not configured correctly*
+  - `localDevelopmentIP`: address (e.g. `12.34.56.89`) of a running local development server.
   - `localDevelopmentPort`: port for local development server (the default grunt server runs on 5002).
   - `deviceAddress`: address (e.g. `12.34.56.78` or `device.local`) of the device to communicate with.
 
@@ -94,6 +94,9 @@ grunt deploy
 ````
 
 Put webapp files onto the device specified in `config.json` by `deviceAddress`. This requires the default `grunt` task to already be running in another terminal and accessible at the address specified by `localDevelopmentIP` in the config file.
+
+_Note: `grunt deploy` will silently fail if the `localDevelopmentIP` address is not configured correctly_
+
 
 ## Release
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "device": "12.34.56.78",
-  "localIP": "12.34.56.89",
-  "port": "5002"
+  "deviceAddress": "12.34.56.78",
+  "localDevelopmentIP": "12.34.56.89",
+  "localDevelopmentPort": "5002"
 }


### PR DESCRIPTION
Changed a few config parameters and docs based on our experience of getting local development up and running.

localIP -> localDevelopmentIP, port -> localDevelopmentPort, device ->
deviceAddress. This makes configuration more clear. Updated
documentation to match and highlighted that deploy will fail silently
if localDevelopmentIP isn’t correctly set.
