### PR TITLE
Fix for 'grunt watch'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /out/webapp/index.html
 /out/webapp/unauthorized.html
 /out/webapp/*.map
+
+public/js/version.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,7 +143,7 @@ module.exports = function(grunt) {
       js: {
         files: ['public/js/*.js', 'public/js/**/*.js'],
         tasks: [
-          'jshint', 'git-describe',
+          'webappVer', 'jshint',
           'buildCopy:dev', 'string-replace:dev',
           'uglify:build', 'compress:build',
           'buildCleanup:dev'],
@@ -169,10 +169,6 @@ module.exports = function(grunt) {
     },
     bumpup: {
       file: 'package.json'
-    },
-    'git-describe': {
-      options: {},
-      build: {}
     },
     shell: {
       options: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-compress": "^0.12.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-git-describe": "^2.3.2",
     "grunt-bumpup": "^0.6.2",
     "grunt-tagrelease": "^0.3.3",
     "grunt-shell": "^1.1.1",


### PR DESCRIPTION
Grunt watch was failing due to two things:
1) Not reading the host / deviceAddress out of config.
2) An unneeded dependency on git-describe without the associated "grunt.loadNpmTasks()".

I'm calling the 'webappVer' subtask which reads the config and removed the git-describe dependency. grunt watch now seems to work as expected.
